### PR TITLE
勤怠一覧画面で月を選択できるように修正

### DIFF
--- a/app/Http/Controllers/Worktime/WorktimeController.php
+++ b/app/Http/Controllers/Worktime/WorktimeController.php
@@ -51,22 +51,36 @@ class WorktimeController extends Controller
 
     }
 
-    public function showWorktimeIndex()
+    public function showWorktimeIndex(Request $request)
     {
+        if($request['month']){
+            $selectedMonth = $request['month'];
+        }else{
+            $selectedMonth = Carbon::now()->format('m');
+        }
+
+        $months = [];
+        for ($i = 1; $i <= 12; $i++) {
+            $month = Carbon::create(null, $i, null, 0, 0, 0);
+            $key = $month->format('m');
+            $value = $month->format('m月');
+            $months[$key] = $value;
+        }
+        
         if(auth()->user()->role === 'admin'){
             $worktimes = Worktime::whereYear('date', now()->year)
-                    ->whereMonth('date', now()->month)
-                    ->orderBy('date', 'asc')
-                    ->paginate(10);
+                        ->whereMonth('date', $selectedMonth)
+                        ->orderBy('date', 'asc')
+                        ->paginate(10);
         } else{
             $worktimes = Worktime::where('user_id', auth()->id())
                         ->whereYear('date', now()->year)
-                        ->whereMonth('date', now()->month)
+                        ->whereMonth('date', $selectedMonth)
                         ->orderBy('date', 'asc')
                         ->paginate(10);
         }
-
-        return view('worktime.index', ['worktimes' => $worktimes]);
+        
+        return view('worktime.index', ['worktimes' => $worktimes, 'months' => $months, 'selectedMonth' => $selectedMonth]);
     }
 
     public function showWorktimeEdit($id)

--- a/resources/views/worktime/index.blade.php
+++ b/resources/views/worktime/index.blade.php
@@ -10,6 +10,25 @@
 
         <x-alert type="danger" :session="session('danger')" />
         
+        @if($worktimes->isEmpty())
+          <div class="alert alert-warning" role="alert">
+              対象月の勤怠情報はありませんでした。
+          </div>
+        @endif
+        
+        <form method="GET" action="{{ route('worktimeIndex') }}">
+          <div class="form-group">
+            <label for="month">月を選択してください</label>
+            <select name="month" class="form-control col-md-2">
+              @foreach($months as $key => $month)
+                <option value="{{ $key }}" <?php if($selectedMonth === $key) echo "selected"; ?>>{{ $month }}</option>
+              @endforeach
+            </select>
+          </div>
+          <button type="submit" class="btn btn-primary">表示</button>
+        </form>
+        </br>
+
         <table class="table table-striped">
             <tr>
                 <th>出勤日</th>


### PR DESCRIPTION
勤怠一覧画面でセレクトボックスを作成し、月を選択できるようにしました。
テーブルに存在しない場合はエラーメッセージを表示しています。